### PR TITLE
Experiment with hippie homegrown web-analytics solution

### DIFF
--- a/blog/_src/page-template.html
+++ b/blog/_src/page-template.html
@@ -98,5 +98,6 @@
     <script type="text/javascript" src="//code.jquery.com/jquery.min.js"></script>
     <script type="text/javascript" src="/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="/js/custom.js"></script>
+    <script type="text/javascript" src="/js/analytics.js"></script>
   </body>
 </html>

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,10 @@
+/* a privacy-respecting analytics server,
+   see http://gasche.ulminfo.fr/neu-prl/statistics/about */
+var analytics_server = "http://gasche.ulminfo.fr/neu-prl/statistics";
+var http = new XMLHttpRequest();
+var hostname = encodeURIComponent(window.location.hostname);
+var url_suffix = window.location.pathname + window.location.search;
+var url = analytics_server + "/visit/" + hostname  + "/" + url_suffix;
+http.open("POST", url, true);
+http.setRequestHeader("Content-length", 0);
+http.send();

--- a/templates.rkt
+++ b/templates.rkt
@@ -70,7 +70,9 @@
      @<!--{Include all compiled plugins (below), or include individual files as needed}
      @script[src: "js/bootstrap.min.js"]
      @<!--{Custom scripts}
-     @script[src: "js/custom.js"]})
+     @script[src: "js/custom.js"]
+     @script[src: "js/analytics.js"]
+  })
 
 @; Copied from `frog/widgets.rkt`
 @(define (twitter-follow-button name label)


### PR DESCRIPTION
Analytics are provided by forcing a POST request on each browser visit
to the website, to a dynamic server I co-administrate and which has
the logic to count visits and render ugly graphs:

  http://gasche.ulminfo.fr/neu-prl/statistics/view/

Using javascript and POST means that we probably won't get hits coming
from bots crawling the server, which means (1) good, no over-inflated
numbers but also (2) we probably won't get visits if people read the
posts from Feedly, TT-RSS or other feed aggregators. This should be
taken as incentives to advertise more effectively on social media.

(I could of course use a GET-based solution solution, but I think this
one is conceptually nicer.)