### PR TITLE
update 'Publications' page

### DIFF
--- a/publications.rkt
+++ b/publications.rkt
@@ -54,6 +54,11 @@
                  SNAPL
                  2017
                  "https://dbp.io/pubs/2017/linking-types-snapl.pdf")
+    (publication "Search for Program Structure"
+                 "Gariel Scherer"
+                 SNAPL
+                 2017
+                 "http://www.ccs.neu.edu/home/gasche/research/canonical-forms/snapl.pdf")
     (publication "Type Systems as Macros"
                  "Stephen Chang, Alex Knauth, Ben Greenman"
                  POPL


### PR DESCRIPTION
I just added my SNAPL paper.

The two still missing publications from the group that I know of are:

- the ESOP'17 paper by Ryan and @cobbal 
- the SNAPL'17 paper by @mfelleisen and others