### PR TITLE
Add fix to make races when deploying much less likely.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -20,6 +20,13 @@ git checkout HEAD -- blog/.gitignore
 git add .
 git status
 git commit -m "$REV"
-echo "Committing..."
 
-git push deploy HEAD:refs/heads/master
+git fetch origin
+CURRENT_HEAD=`git rev-parse origin/master`
+if [ "$TRAVIS_COMMIT" = "$CURRENT_HEAD" ]
+then
+    echo "Committing..."
+    git push deploy HEAD:refs/heads/master
+else
+    echo "Aborting; detected race..."
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,4 +29,5 @@ then
     git push deploy HEAD:refs/heads/master
 else
     echo "Aborting; detected race..."
+    exit 1
 fi


### PR DESCRIPTION
@gasche @bennn 

Here's the quick fix I suggested. See the commit for description, but it matches our email thread.

I have _not_ tested this on Travis -- it's somewhat of a pain to test (I did test the shell conditional syntax locally), so as long as it looks good to y'all, we should just push it and if it doesn't work I'll fix it (i.e., test it live!).

I looked into submitting the issue if things go wrong, but it didn't look trivial (there is a gem `ghi` that allows you to do this, but you need to authenticate, and it doesn't seem like it'll use the same `.netrc` that we use for authenticating with git). 