### PR TITLE
Syntax highlighting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ env:
     - RACKET_VERSION=6.6
     - secure: "ZD05u6G77v1POOF2bl423H/vqgS5e/9ok/UCG57dDITBoIXun2hj0cJKBT8SFoW58yyYNd3Ji+mbNvwXRZ6f0+OkLB5rIZqWDaz9tlVcnDk4BfwlXbo7v0uMnmqehp+ftaZKhyDJSYhOR9cMNxaTmSeINuTX3rT1lk8QxQy5MW5u+ouwkVQia0dFe66mWbGFH0u55t8Wwxgo+l0mb1OSpri7AbgOou3+0BPoHB0G65uhRXGyE033CXo9WodMcMtZJDslbQ80ZOec/XHSXAszItc/HPdBzt4h8aGOFm7gW/TmpF76uWsgshDyxVtUJsdlwvb65A6FB8B9/NTSkw55/n8FUImhg5A1fuSdwLfV7SpjzWbjuHhMisuXJ7JatWk2FD7pclEP97HmMRSVlDFacQ1sqUwqX3R8i3OXd1/K4RNDYExabl2qzQ+PLiaZPXf/lOX2VJvd64BcGveQIoGEYr/+SPhSn/ss9rlY3MH4unTHUqZ77iZKFhT782nREpLZkaRr27OcH5P511X6hzkynTYlRjyfKBns5b1uMYE1rWBYshAxlWhZVY2pZkj7axvzM/XOkzC4AnrxmmBVFF1vKDPtn1OydrCmTvdAVxdLy9VNz6QRDHB6lKJWgUvqKdKqtfOz3aBCyMFWxqH0mpTywPeXah558LgP571sCuHbIUo="
 
+addons:
+  apt:
+    packages:
+    - python-pygments
+
 # NOTE(dbp 2016-09-30): frog seems to need a running X server... :(
 before_install:
   - "export DISPLAY=:99.0"

--- a/blog/_src/posts/2017-05-23-scribble-html.md
+++ b/blog/_src/posts/2017-05-23-scribble-html.md
@@ -79,14 +79,14 @@ These functions have the same name as the corresponding HTML tag.
 
 Example program:
 
-```
+```racket
 #lang scribble/html
 @p{Hello World}
 ```
 
 Running this program prints:
 
-```
+```html
 <p>Hello World</p>
 ```
 
@@ -98,14 +98,14 @@ Every tag-rendering function accepts "Racket mode" arguments that specify
 
 For example:
 
-```
+```racket
 #lang scribble/html
 @p[style: "color:red"]{Hello World}
 ```
 
 Prints:
 
-```
+```html
 <p style="color:red">Hello World</p>
 ```
 
@@ -124,7 +124,7 @@ There is no extra support for HTML.
 
 To compare, here's the start of the old homepage:
 
-```
+```racket
 #lang scribble/text
 @(require "templates.rkt")
 
@@ -138,7 +138,7 @@ To compare, here's the start of the old homepage:
 
 And here is the start of the `scribble/html`'d homepage:
 
-```
+```racket
 #lang scribble/html
 @require["templates.rkt"]
 
@@ -175,19 +175,19 @@ This is very very helpful.
 Before, the [Teaching page](http://prl.ccs.neu.edu/teaching.html) contained
  some interesting HTML for rendering vertical text (look for the word "Semantics" to see how this was used):
 
-```
+```html
 <span class="how-to-design-programs">S<br />e<br />m<br />a<br />n<br />t<br />i<br />c<br />s<br /><br /></span>
 ```
 
 After, the same text is generated from a function call:
 
-```
+```racket
 @span[class: "how-to-design-programs"]{@vertical-text{Semantics}}
 ```
 
 The `vertical-text` function is simple:
 
-```
+```racket
 @require[(only-in racket/list add-between)]
 
 @(define (vertical-text . str*)
@@ -199,7 +199,7 @@ The `vertical-text` function is simple:
 
 Here's part of the old definition of "Ben Greenman" on the [People page](http://prl.ccs.neu.edu/people.html):
 
-```
+```html
 <div class="row pn-person">
   <div class="col-md-12 pn-row-eq-height">
     <div class="col-md-3 pn-photo">
@@ -228,7 +228,7 @@ Here's part of the old definition of "Ben Greenman" on the [People page](http://
 The new definition uses a helper function with keyword arguments for each
  "field" of the person:
 
-```
+```racket
 @person[#:name "Ben Greenman"
         #:title "Advisor: Matthias Felleisen"
         #:e-mail "types@ccs.neu.edu"
@@ -244,14 +244,14 @@ The new definition uses a helper function with keyword arguments for each
 
 Before, the code did a lot of string formatting ([link](https://github.com/nuprl/website/commit/a0600d#diff-1921e33ce89be28dd277cf1c7880d1beL9)):
 
-```
+```racket
 (define (link url body)
   (string-append "<a href=\"" url "\">" body "</a>"))
 ```
 
 The new code has no need for such helper functions.
 
-```
+```racket
 @a[href: url body]
 ```
 


### PR DESCRIPTION
On my machine syntax highlighting works, and according to [this frog documentation page](https://github.com/greghendershott/frog/blob/master/example/_src/posts/2012-01-01-a-2012-blog-post.md) it is because I have Pygments installed. So I tried to make the Travis CI install Pygments when it builds the website, but I have no way to test besides sending a PR, so there it is. (And then I don't know if we can check whether highlighting actually works without merging it.)