### PR TITLE
[blog] move mathjax definitions, removes extra whitespace

### DIFF
--- a/blog/_src/posts/2017-06-05-syntactic-parametricity-strikes-again.md
+++ b/blog/_src/posts/2017-06-05-syntactic-parametricity-strikes-again.md
@@ -2,15 +2,6 @@
     Date: 2017-06-05T14:27:44
     Tags: by Gabriel Scherer, by Li-Yao Xia
 
-\\[
-\newcommand{\List}[1]{\mathsf{List}~#1}
-\newcommand{\Fin}[1]{\mathsf{Fin}~#1}
-\newcommand{\Nat}[1]{\mathbb{N}}
-\newcommand{\rule}[2]{\frac{\displaystyle \array{#1}}{\displaystyle #2}}
-\newcommand{\judge}[2]{{#1} \vdash {#2}}
-\newcommand{\emptyrule}[1]{\begin{array}{c}\\[-1em] #1 \end{array}}
-\\]
-
 In this blog post, reporting on a collaboration with [Li-Yao
 Xia](https://poisson.chat/), I will show an example of
 how some results that we traditionally think of as arising from free
@@ -18,6 +9,12 @@ theorems / parametricity can be established in a purely "syntactic" way,
 by looking at the structure of canonical derivations. More precisely,
 I prove that
 \\(
+\newcommand{\List}[1]{\mathsf{List}~#1}
+\newcommand{\Fin}[1]{\mathsf{Fin}~#1}
+\newcommand{\Nat}[1]{\mathbb{N}}
+\newcommand{\rule}[2]{\frac{\displaystyle \array{#1}}{\displaystyle #2}}
+\newcommand{\judge}[2]{{#1} \vdash {#2}}
+\newcommand{\emptyrule}[1]{\begin{array}{c}\\[-1em] #1 \end{array}}
   ∀α. \List α → \List \alpha
 \\)
 is isomorphic to


### PR DESCRIPTION
@gasche  

Here's the abstract before this PR:
![screen shot 2017-06-09 at 21 21 22](https://user-images.githubusercontent.com/1731829/26998872-da3145de-4d58-11e7-9de4-0ac63c35c351.png)

And here it is after:
![screen shot 2017-06-09 at 21 20 51](https://user-images.githubusercontent.com/1731829/26998873-e582e758-4d58-11e7-85c2-c2562cbbc459.png)
