### PR TITLE
Print just "link" instead of URL for papers on Pubs page

### DIFF
--- a/publications.rkt
+++ b/publications.rkt
@@ -1142,7 +1142,7 @@
        @(when link
           @list{
             @span[class: "pn-pub-link"]{
-              [@a[class: "pn-url" href: link link]]}})
+              [@a[class: "pn-url" href: link]{link @span[class: "glyphicon glyphicon-link"]}]}})
        @br{}
        @span[class: "pn-authors" authors]
        @br{}


### PR DESCRIPTION
[pubs page manager hat on] This change was proposed by @janvitek, I support it. 

*Discussion*
Long and diverse URLs are ugly. The only downside I see: with the current font size settings the `[link]` link is a bit hard to target. I would argue for enlargement of the font size site-wide: it seems that the current size was chosen in the era of 640x480. That should go as a separate PR, of course.