### PR TITLE
+oopsla 2018 papers

### DIFF
--- a/publications.rkt
+++ b/publications.rkt
@@ -52,6 +52,31 @@
 
 @(define publications
    (list
+    (publication "Collapsible Contracts: Fixing a Pathology of Gradual Typing"
+                 "Daniel Feltey, Ben Greenman, Christophe Scholliers, Robby Findler, and Vincent St-Amour"
+                 OOPSLA
+                 2018
+                 "http://www.ccis.northeastern.edu/~types/publications/collapsible/fgsfs-oopsla-2018.pdf")
+    (publication "Finding Broken Promises in Asynchronous JavaScript Programs"
+                 "Saba Alimadadi, Di Zhong, Magnus Madsen, and Frank Tip"
+                 OOPSLA
+                 2018
+                 "http://ece.ubc.ca/~saba/dl/promisekeeper.pdf")
+    (publication "Julia Subtyping: a Rational Reconstruction"
+                 "Francesco Zappa Nardelli, Julia Belyakova, Artem Pelenitsyn, Benjamin Chung, Jeff Bezanson, and Jan Vitek"
+                 OOPSLA
+                 2018
+                 "http://janvitek.org/pubs/oopsla18a.pdf")
+    (publication "Julia: Dynamism and Performance Reconciled by Design"
+                 "Jeff Bezanson, Benjamin Chung, Jiahao Chen, Stefan Karpinski, Viral B Shah, Jan Vitek, and Lionel Zoubritzky"
+                 OOPSLA
+                 2018
+                 "http://janvitek.org/pubs/oopsla18b.pdf")
+    (publication "Test Generation for Higher-Order Functions in Dynamic Languages"
+                 "Marija Selakovic, Michael Pradel, Rezwana Karim Nawrin, and Frank Tip"
+                 OOPSLA
+                 2018
+                 "http://software-lab.org/publications/oopsla2018_LambdaTester.pdf")
     (publication "Rank Polymorphism Viewed as a Constraint Problem"
                  "Justin Slepak, Panagiotis Manolios, and Olin Shivers"
                  ARRAY


### PR DESCRIPTION
Hello all,

Please review the list of OOPSLA papers pushed by the lab this year. Ping me if:

1. I miss something. This is not only OOPSLA but everything you published recently.
2. The URLs in this PR is not what you would like. This time I managed to google all the PDFs on the authors' personal homepages. In the future, if I fail with Google, I just put DOI-link, and if there is no one, leave it empty.