### PR TITLE
blog: Java and migratory typing

### DIFF
--- a/blog/_src/posts/2018-12-02-java-transient.md
+++ b/blog/_src/posts/2018-12-02-java-transient.md
@@ -3,7 +3,8 @@
     Tags: migratory typing, java, by Ben Greenman
 
 The _transient_ approach to migratory typing (circa [2014](http://homes.sice.indiana.edu/mvitouse/papers/dls14.pdf))
- is similar to type erasure in Java (circa [2004](https://docs.oracle.com/javase/1.5.0/docs/relnotes/features.html)).
+  is similar to type erasure in Java (circa [2004](https://docs.oracle.com/javase/1.5.0/docs/relnotes/features.html))
+  in a few interesting ways.
 
 <!-- more -->
 
@@ -23,22 +24,22 @@ There are tradeoffs involved in the implementation of a migratory typing
 
 A typical migratory typing system adds a static type checker to a dynamically
  typed language ([examples](/blog/2018/10/06/a-spectrum-of-type-soundness-and-performance/index.html)),
- but one could also extend the type system of a statically-typed language
- (e.g., by [adding dependent types](https://hal.inria.fr/hal-01629909v2)).
+ but one could also extend the type system of a statically-typed language;
+ for example, by [adding dependent types](https://hal.inria.fr/hal-01629909v2).
 In this sense, Java 1.5.0 is a migratory typing system for pre-generics Java.
 The addition of generic types enabled new ahead-of-time checks and maintained backwards
  compatibility with existing Java code.
 
 Java's implementation of migratory typing has some interesting things in common
  with the _transient_ implementation strategy recently proposed by
- Michael Vitousek and collaborators.
+ Michael Vitousek and collaborators ([DLS'14](http://homes.sice.indiana.edu/mvitouse/papers/dls14.pdf), [POPL'17](https://mail.google.com/mail/u/0/h/1atrn21qlyrrh/?&)).
 The goal of this post is to demonstrate the connections.
 
 
 ## Erasure migratory typing
 
-Before we compare Java 1.5.0 to transient, let's review a strategy that
- pre-dates and informs them both: the _erasure_ approach to migratory typing.
+Before we compare Java 1.5.0 to transient, let's review a simpler strategy:
+ the _erasure_ approach to migratory typing.
 
 [TypeScript](https://www.typescriptlang.org/) is a great (modern) example of the erasure approach.
 TypeScript is a migratory typing system for JavaScript.
@@ -77,8 +78,8 @@ On one hand, this means the type annotations have no effect on the behavior
 On the other hand, it means that an experienced JavaScript programmer can
  re-use their knowledge to predict the behavior of a TypeScript program.
 
-More generally, the run-time guarantees of TypeScript are the same
- as the run-time guarantees of JavaScript (in an ordinary program):
+In an ordinary program, the run-time guarantees of TypeScript are simply
+ the run-time guarantees of JavaScript:
 
 - if a TypeScript expression `e` has the static type `T` and evaluates to
  a value `v`,
@@ -89,9 +90,9 @@ More generally, the run-time guarantees of TypeScript are the same
 ## Transient migratory typing
 
 [Reticulated](https://github.com/mvitousek/reticulated) is a migratory typing
- system for Python that follows a so-called _transient_ implementation strategy.
+ system for Python that follows a _transient_ implementation strategy.
 A Reticulated module gets type-checked and compiles to a Python module that
- defends itself from _certain_ type-invalid inputs through the use of
+ defends itself from certain type-invalid inputs through the use of
  assertions that run in near-constant time.
 The type-checking addresses goal **G1**,
  the compilation to Python provides interoperability (goal **G3**),
@@ -100,7 +101,7 @@ The type-checking addresses goal **G1**,
 > These _certain_ inputs are the ones that would cause a standard typed
 > operational semantics to reach an undefined state.
 > For a discussion of _near-constant_, see
-> [On the Cost of Type-Tag Soundness, section 2](http://www.ccs.neu.edu/home/types/publications/publications.html#gm-pepm-2018).
+> [_On the Cost of Type-Tag Soundness_, section 2](http://www.ccs.neu.edu/home/types/publications/publications.html#gm-pepm-2018).
 
 For example, here is a Reticulated function
  that computes the average of a list of numbers:
@@ -139,7 +140,8 @@ The Reticulated compiler removes all type annotations and inserts `check_type`
 In `average`, these assertions check that: (1) the input is a list,
  (2) the output is a `float`, (3) and the names `sum` `len` and
  `ValueError` point to callable values.
-That's all; the assertions **do not check** that `nums` contains only floating-point
+That's all.
+The assertions **do not check** that `nums` contains only floating-point
  numbers.
 
 > The assertions also do not check that the function bound to `sum` is defined
@@ -220,7 +222,9 @@ and some calls to `get` must be followed by a type cast:
 ((String) sBox.get()).charAt(0);
 ```
 
-**With generics**, we can give a name (e.g. `ValType`) to "the type of the value inside a box":
+- - -
+
+With generics, we can give a name (e.g. `ValType`) to "the type of the value inside a box":
 
 ```
 class GBox<ValType> {
@@ -250,7 +254,8 @@ sBox.get().charAt(0); // no cast, good!
 
 Java generics are backwards-compatible with older code (goal **G3**).
 This means that pre-generics code can interact with instances of a generic
- class (and vice-versa, generic code can interact with pre-generics classes).
+ class.
+Vice-versa, generic code can interact with pre-generics classes.
 Since pre-generics code is not aware of type parameters, these interactions
  are potentially unsafe.
 For example, a pre-generics method can change the type of a `GBox`:
@@ -357,7 +362,7 @@ Nevertheless, the implementation of generic-type erasure + cast insertion
 Alternatively, Java could enforce generic types at run-time.
 Over the years there have been a few proposals to do so ([example 1](http://gafter.blogspot.com/2006/11/reified-generics-for-java.html),
  [example 2](https://wiki.openjdk.java.net/display/valhalla/Main)).
-NB: the C# language has a similar type system and does enforce
+The C# language has a similar type system and does enforce
  generics at run-time (sources:
  [blog post](https://mattwarren.org/2018/03/02/How-generics-were-added-to-.NET/),
  [PLDI 2001 paper](https://www.microsoft.com/en-us/research/publication/design-and-implementation-of-generics-for-the-net-common-language-runtime/),
@@ -366,5 +371,5 @@ NB: the C# language has a similar type system and does enforce
 
 ## Acknowledgments
 
-Thank you to Ryan Culpepper and Jesse Tov for noticing the similarity between
+Thank you to [Ryan Culpepper](https://github.com/rmculpepper) and [Jesse Tov](http://users.eecs.northwestern.edu/~jesse/) for noticing the similarity between
  Java's generic-type erasure and transient migratory typing.

--- a/blog/_src/posts/2018-12-02-java-transient.md
+++ b/blog/_src/posts/2018-12-02-java-transient.md
@@ -358,8 +358,10 @@ Alternatively, Java could enforce generic types at run-time.
 Over the years there have been a few proposals to do so ([example 1](http://gafter.blogspot.com/2006/11/reified-generics-for-java.html),
  [example 2](https://wiki.openjdk.java.net/display/valhalla/Main)).
 NB: the C# language has a similar type system and does enforce
- generics at run-time; for the implementation details, see
- [ECMA TR/89](http://www.ecma-international.org/publications/techreports/E-TR-089.htm).
+ generics at run-time (sources:
+ [blog post](https://mattwarren.org/2018/03/02/How-generics-were-added-to-.NET/),
+ [PLDI 2001 paper](https://www.microsoft.com/en-us/research/publication/design-and-implementation-of-generics-for-the-net-common-language-runtime/),
+ [backup link to paper](https://dl.acm.org/citation.cfm?doid=378795.378797))
 
 
 ## Acknowledgments

--- a/blog/_src/posts/2018-12-02-java-transient.md
+++ b/blog/_src/posts/2018-12-02-java-transient.md
@@ -1,6 +1,6 @@
     Title: Java and Migratory Typing
     Date: 2018-12-02T14:41:53
-    Tags: migratory typing, gradual typing, java, by Ben Greenman
+    Tags: migratory typing, java, by Ben Greenman
 
 The _transient_ approach to migratory typing (circa [2014](http://homes.sice.indiana.edu/mvitouse/papers/dls14.pdf))
  is similar to type erasure in Java (circa [2004](https://docs.oracle.com/javase/1.5.0/docs/relnotes/features.html)).

--- a/blog/_src/posts/2018-12-02-java-transient.md
+++ b/blog/_src/posts/2018-12-02-java-transient.md
@@ -1,0 +1,113 @@
+    Title: Java and Migratory Typing
+    Date: 2018-12-02T14:41:53
+    Tags: migratory typing, gradual typing, java, by Ben Greenman
+
+The _transient_ approach to migratory typing (circa 2014)
+ is similar to type erasure in Java (circa 2004).
+
+<!-- more -->
+
+## Migratory typing
+
+The goal of _migratory typing_ is to enrich the type system of a language
+ without breaking backwards compatibility.
+Ideally, code that uses the enriched types:
+
+- (G1) benefits from new ahead-of-time checks,
+- (G2) benefits from stronger run-time guarantees, and
+- (G3) may interact with all kinds of existing code.
+
+There are tradeoffs involved in the implementation of a migratory typing
+ system, however, and different implementations may focus on different goals
+ that the three above.
+
+A typical migratory typing system adds a static type checker to a dynamically
+ typed language ([examples](/blog/2018/10/06/a-spectrum-of-type-soundness-and-performance/index.html)),
+ but one could also extend the type system of a statically-typed language.
+In this sense, Java 1.5.0 is a migratory typing system for pre-generics Java.
+Adding generics enabled new ahead-of-time checks and maintained backwards
+ compatibility with existing Java code.
+
+Java's implementation of migratory typing has some interesting things in common
+ with the _transient_ implementation strategy recently proposed by
+ Michael Vitousek and collaborators.
+The goal of this post is to spell out the connections.
+
+
+## Erasure migratory typing
+
+Before we compare Java 1.5.0 to _transient_, lets review a strategy that
+ predates and informs them both: the _erasure_ approach to migratory typing.
+
+[TypeScript](CITE) is a great example of the erasure approach.
+TypeScript is a migratory typing system for JavaScript.
+A TypeScript module gets validated by an ahead-of-time type checker and
+ compiles to JavaScript.
+After compilation, any JavaScript program may import bindings
+ from the generated code.
+Conversely, a TypeScript module may import bindings from a JavaScript module
+ by declaring a static type for each binding [link](CITE).
+
+The compiler works by erasing types.
+Every type `T` in the source code translates to the universal "JavaScript type".
+For instance, a TypeScript function declaration compiles to an untyped
+ JavaScript function:
+
+<!-- TODO use real TypeScript -->
+```
+(function(number n0, number n1) { return n0 + n1; })
+// ==(compiles to)==>
+(function(n0, n1) { return n0 + n1; })
+```
+
+TypeScript satisfies goals **G1** and **G3** for a migratory typing system
+ because its type checker adds ahead-of-time checks and its
+ compiler outputs JavaScript.
+TypeScript does not satisfy goal **G2** because the compiler erases types.
+In terms of the example above, the compiled function may be invoked with any
+ pair of JavaScript values; the variable `n0` is not guaranteed to point
+ to a `number` at run-time.
+On one hand, this means the type annotations have no effect on the behavior
+ of a program --- and in particular, cannot be trusted for debugging.
+On the other hand, it means that an experienced JavaScript programmer can
+ re-use their knowledge to predict the behavior of a TypeScript program.
+
+More generally, the run-time guarantees of TypeScript are the same
+ as the run-time guarantees of JavaScript (in an ordinary program).
+If a TypeScript expression `e` has the static type `T` and evaluates to
+ a value `v`, the only guarantee is that `v` is a valid JavaScript value
+ --- `T` could be `number` and `v` could be an object.
+
+
+## Transient migratory typing
+
+[Reticulated]() is a migratory typing system for Python that follows a
+ so-called _transient_ implementation strategy.
+Reticulated/transient first appeared in the academic literature in 2014,
+ and was introduced as an approach that provides run-time guarantees (goal **G2**)
+ without using proxy values.
+<!-- link to proxies -->
+
+> 
+
+
+
+
+
+## Links
+
+Erasure pioneered in common lisp / maclisp, Strongtalk for manifesto
+
+SNAPL 17 for an MT retrospective
+
+POPL 17 for transient <!-- TODO add Mike's dissertation when finished -->
+
+(and [gradual typing](SNAPL15)) is related
+
+dependent interoperability
+
+
+## Acknowledgments
+
+Thank you to Ryan Culpepper and Jesse Tov for noticing the similarity between
+ Java type erasure and _transient_ migratory typing.


### PR DESCRIPTION
This post argues that Java is a migratory typing system, and shows how it is pretty similar to the transient idea for Reticulated Python.

I couldn't find details online about how `javac` inserts casts, so that's missing from the post.

Any other suggestions about technical content to add would be welcome