### PR TITLE
Update some links

### DIFF
--- a/index.rkt
+++ b/index.rkt
@@ -15,8 +15,8 @@
           @div[class: "col-md-12"]{
             @img[src: "img/prl.png" alt: "Programming Research Laboratory"]{
               @h1{Programming Research Laboratory @location-link["https://prl.ccs.neu.edu/contact.html#directions" "66%"]}
-              @h2{College of Computer and Information Science, WVH 308 @location-link["http://www.ccs.neu.edu/" "64%"]}
-              @h3{Northeastern University @location-link["http://www.neu.edu/" "62%"]}
+              @h2{College of Computer and Information Science, WVH 308 @location-link["https://www.ccis.northeastern.edu" "64%"]}
+              @h3{Northeastern University @location-link["https://www.northeastern.edu" "62%"]}
               @h4{Boston @location-link["https://www.boston.gov/" "60%"]}}}}}}
 
     @div[class: "pn-main-wrapper"]{

--- a/new-members.rkt
+++ b/new-members.rkt
@@ -16,12 +16,12 @@
               @ol[
                 @li{
                   Get your student ID (a.k.a. Husky Card) from
-                  @a[href: "http://www.northeastern.edu/huskycard/about/pick-up-locations/"]{a pick-up location}.
+                  @a[href: "https://www.northeastern.edu/huskycard/about/pick-up-locations/"]{a pick-up location}.
                   Visit WVH 202 and/or send mail to @mailto|{operations@ccs.neu.edu}| to register your card to unlock WVH 308, WVH 330, WVH 366, and your private office (if you have one).
                 }
                 @li{
                   Apply for a CCIS account using
-                  @a[href: "http://howto.ccs.neu.edu/howto/accounts-homedirs/how-to-sign-up-for-a-ccis-account/"]{these instructions}.
+                  @a[href: "https://www.ccis.northeastern.edu/systems/getting-started/"]{these instructions}.
                   This account comes with a @tt{ccs.neu.edu} email address and
                   allows you to access various computers around the college.
                   Make sure you are able to print using the @tt{gaugin} (in WVH 308)

--- a/templates.rkt
+++ b/templates.rkt
@@ -39,10 +39,10 @@
      @<!--{Custom css}
      @link[href: "css/custom.css" rel: "stylesheet"]
      @<!--{Fonts}
-     @link[href: "http://fonts.googleapis.com/css?family=Ubuntu:300"
+     @link[href: "https://fonts.googleapis.com/css?family=Ubuntu:300"
            rel: "stylesheet"
            type: "text/css"]
-     @link[href: "http://fonts.googleapis.com/css?family=PT+Sans"
+     @link[href: "https://fonts.googleapis.com/css?family=PT+Sans"
            rel: "stylesheet"
            type: "text/css"]
 


### PR DESCRIPTION
I noticed that if you go to https://prl.ccs.neu.edu instead of http://prl.ccs.neu.edu, the fonts are broken. This is because fonts are loaded over http, not https.

I also updated a few old links. (*.neu.edu redirects to *.northeastern.edu and forces https.)

Question: do we want to [enforce https](https://help.github.com/articles/securing-your-github-pages-site-with-https/)? If we do, then I think we break #43 because our analytics sends requests over http.