### PR TITLE
Improve the order of seminars

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ hosted at prl.ccs.neu.edu.
 Any changes made to the `master` branch here will get deployed
 automatically to `prl.ccs.neu.edu`.
 
+Note that we configure a [cron job](https://docs.travis-ci.com/user/cron-jobs/)
+to rebuild so that the list of seminars shows up in the right order (as it
+needs to change after every seminar).
+
+
 Building
 ========
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -324,7 +324,10 @@ ul
     cursor: pointer;
 }
 
-.pn-seminar.compact.finished .pn-name, .pn-seminar.finished .pn-title-separator, .pn-seminar.finished .pn-title
+.pn-seminar.compact.finished .pn-name,
+.pn-seminar.finished .pn-title-separator,
+.pn-seminar.finished .pn-title,
+.pn-seminar.compact.finished a
 {
   color: #B5B4B4;
 }
@@ -347,7 +350,6 @@ ul
 
 .pn-seminar.compact a
 {
-  color: #B5B4B4;
   text-decoration: none;
 }
 


### PR DESCRIPTION
This took longer than expected, because my Racket-fu is weak and my Scribble-fu is weaker. Comments are welcome.

Before merging, let me know so I can set up the [cron job](https://docs.travis-ci.com/user/cron-jobs/).

CSS fix (note that this is an upcoming seminar), before and after:
![image](https://user-images.githubusercontent.com/547059/51332660-1d1f3f80-1a4a-11e9-9066-751197e34c4c.png)
![image](https://user-images.githubusercontent.com/547059/51332532-e9dcb080-1a49-11e9-87a1-292af016049e.png)

Commit message below:

```
Upcoming seminars show up first, in chronological order, so the next
seminar is first. Afterwards, past seminars are displayed in reverse
chronological order, so the most recent seminar is first. For example:

 - NEXT SEMINAR
 - NEAR FUTURE
 - FAR FUTURE
 - most recent seminar
 - near past
 - far past

This required a few other changes, such as defining a `seminar` struct
to defer the Scribble rendering until after the partition and sorting.

Note that the sorting is done in the build step, so we also have to
ensure the build system (Travis) builds every night. This also depends
on time zones being properly configured on Travis... (A future
enhancement might be to do the sorting on the client-side in
JavaScript.)

Fixes #167

---

Along the way, I made other minor fixes:

 - fix some CSS
 - fix generated HTML (there was some invalid nesting of p and span)
 - make generated HTML more readable (by inserting new lines)
 - remove some JavaScript from each seminar, which 'collapsed' past
   seminars, because we do that statically now
```