### PR TITLE
add 'Upcoming Seminars' and 'Past Seminars' headings

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -577,3 +577,21 @@ ul
     margin-bottom: 18px;
   }
 
+
+/* ensure <hr> renders a horizontal line in HTML5 <https://stackoverflow.com/questions/27215472/html5-tag-for-horizontal-line-break> */
+hr
+{
+  display: block;
+  position: relative;
+  padding: 0;
+  margin: 8px auto;
+  height: 0;
+  width: 100%;
+  max-height: 0;
+  font-size: 1px;
+  line-height: 0;
+  clear: both;
+  border: none;
+  border-top: 1px solid #aaaaaa;
+  border-bottom: 1px solid #ffffff;
+}

--- a/seminars.rkt
+++ b/seminars.rkt
@@ -1371,8 +1371,13 @@ a Dr. sc. ETH in 2012.
          @br{}
 
         @div[class: "row"]{
-          @|future-sems|
-          @|past-sems|
+          @div[class: "col-md-12"]{
+            @h3{Upcoming Seminars}
+            @|future-sems|
+            @hr[]
+            @h3{Past Seminars}
+            @|past-sems|
+          }
         }
 
         @div[class: "pn-separator-img"]


### PR DESCRIPTION
Add two new headings to the seminars page to explain the new organization (#175)

Picture of 1st new heading:
![screen shot 2019-01-30 at 12 36 49](https://user-images.githubusercontent.com/1731829/52000624-9af03b80-248b-11e9-9ebc-e549ef06cc5f.png)

Picture of 2nd new heading:
![screen shot 2019-01-30 at 12 36 58](https://user-images.githubusercontent.com/1731829/52000645-a17eb300-248b-11e9-9737-7250035bdd07.png)


Should the labels say "Future Seminars" / "Past Seminars" instead? Something else?