### PR TITLE
deployment script: switch to Utah server for now, while Boston server is down

### DIFF
--- a/install-racket.sh
+++ b/install-racket.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-curl -L -o racket-6.6-x86_64-linux.sh https://mirror.racket-lang.org/installers/6.6/racket-6.6-x86_64-linux.sh
+curl -L -o racket-6.6-x86_64-linux.sh https://www.cs.utah.edu/plt/installers/6.6/racket-6.6-x86_64-linux.sh
 chmod u+rx racket-6.6-x86_64-linux.sh
 ./racket-6.6-x86_64-linux.sh<<EOF
 no


### PR DESCRIPTION
This is a stop-gap measure already applied on the racket-lang.org, while folks are figuring out the state of mirror.racket-lang.org.