### PR TITLE
use xvfb 'service' in travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ addons:
     - python-pygments
 
 # NOTE(dbp 2016-09-30): frog seems to need a running X server... :(
+# NOTE(ben g 2019-08-20): <https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui>
+services:
+  - xvfb
+
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - ./install-racket.sh
   - export PATH="${RACKET_DIR}/bin:${PATH}"
 


### PR DESCRIPTION
The build of #203 failed ([travis link](https://travis-ci.org/nuprl/website/builds/573962123?utm_source=github_status&utm_medium=notification), [full log](https://github.com/nuprl/website/files/3521191/nuprl-website-913.txt)). I think this PR will fix it.

Sources:
- https://stackoverflow.com/questions/55674746/travis-sh-0-cant-open-etc-init-d-xvfb
- https://benlimmer.com/2019/01/14/travis-ci-xvfb/
- https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui