### PR TITLE
fix number formatting in code blocks

### DIFF
--- a/css/pygments.css
+++ b/css/pygments.css
@@ -39,11 +39,13 @@
 .nv { color: #008080 } /* Name.Variable */
 .ow { color: #000000; font-weight: bold } /* Operator.Word */
 .w { color: #bbbbbb } /* Text.Whitespace */
-.mf { color: #ffffff } /* Literal.Number.Float */
-.mh { color: #ffffff } /* Literal.Number.Hex */
-.mi { color: #ffffff } /* Literal.Number.Integer */
-.mo { color: #ffffff } /* Literal.Number.Oct */
-.mn { color: #ffffff } /* Literal.Number */
+
+/* see https://github.com/nuprl/website/issues/224#issuecomment-534255324 */
+.code .mf { color: #009999 } /* Literal.Number.Float */
+.code .mh { color: #009999 } /* Literal.Number.Hex */
+.code .mi { color: #009999 } /* Literal.Number.Integer */
+.code .mo { color: #009999 } /* Literal.Number.Oct */
+
 .sb { color: #d01040 } /* Literal.String.Backtick */
 .sc { color: #d01040 } /* Literal.String.Char */
 .sd { color: #d01040 } /* Literal.String.Doc */


### PR DESCRIPTION
Fixes #224
- for code blocks this revert the style to the default state (before it was changed by #85)
- for math the new definition has the same output as after #85, that is, not-completely-horrible

The fix was suggested by Ben in
  https://github.com/nuprl/website/issues/224#issuecomment-534272207

It could be reasonable to qualify *all* CSS settings of this file to code blocks. I only went for the fix of minimal invasiveness (in terms of diff in this PR, or diff with respect to the pre-#85 state).