### PR TITLE
blog: remove 'Google Plus share' button

### DIFF
--- a/blog/_src/post-template.html
+++ b/blog/_src/post-template.html
@@ -7,7 +7,6 @@
   <br/><br/>
   <footer>
     @twitter-share-button[full-uri]
-    @google-plus-share-button[full-uri]
     @older/newer-links[older-uri older-title newer-uri newer-title]
   </footer>
 </article>


### PR DESCRIPTION
Because Google is killing Google+

Closes #150