### PR TITLE
Blog: add Disqus comments loaded on-demand if client explicitly asks

### DIFF
--- a/blog/_src/post-template.html
+++ b/blog/_src/post-template.html
@@ -5,6 +5,24 @@
   </header>
   @|content|
   <br/><br/>
+  <p>
+  <div id="disqus_thread">
+    <a href="#" onclick="loadDisqus(); return false;">
+      <b>(Show comments / Powered by Disqus)</b>
+    </a>
+  </div>
+  </p>
+  <script>
+    function loadDisqus() {
+      var dsq = document.createElement('script');
+      dsq.type = 'text/javascript';
+      dsq.async = true;
+      dsq.src = 'https://neuprl.disqus.com/embed.js';
+      (document.getElementsByTagName('head')[0] ||
+        document.getElementsByTagName('body')[0]).appendChild(dsq);
+    };
+  </script>
+  <br/>
   <footer>
     @twitter-share-button[full-uri]
     @older/newer-links[older-uri older-title newer-uri newer-title]


### PR DESCRIPTION
This addresses #98 by adding optional comments powered by Disqus. The comments (and corresponding JS code of Disqus) are not loaded unless the user explicitly asks so.

Previews (click to expand):

<details>
  <summary>Screnshot: comments have not been loaded yet (the default)</summary>
<img src="https://user-images.githubusercontent.com/6832600/87317952-adcac480-c4f5-11ea-9f4e-b8e70d829dd5.png" ald="comments-1">
</details>

<details>
  <summary>Screnshot: comments have been loaded after the client clicked "Show comments" (see the previous screenshot)</summary>
<img src="https://user-images.githubusercontent.com/6832600/87318002-c044fe00-c4f5-11ea-9b89-17fd40855cb1.png" ald="comments-2">
</details>
