### PR TITLE
Add authors to blog posts

### DIFF
--- a/blog/.frogrc
+++ b/blog/.frogrc
@@ -15,8 +15,14 @@ uri-prefix = /blog
 # The title of the blog. Used when generating feeds.
 title = PRL Blog
 
-# The author. Used when generating feeds, and provided to
+# The default author. Used when generating feeds, and provided to
 # `page-template.html` as the template variable `@author`.
+#
+# Note that each post may have `Authors:` metadata naming one or more
+# authors. In that case those author(s) are used for feed data. Both
+# `index-template.html` and `post-template.html` get an `authors`
+# template variable that is either post-specific author(s) or the
+# default author here.
 author = PRL
 
 # What editor to launch with --edit. $EDITOR means to use $EDITOR from

--- a/blog/README.md
+++ b/blog/README.md
@@ -9,7 +9,8 @@ Creating Posts
 
 1. Run `raco frog -n "TITLE"`
 2. Edit the newly-generated markdown file
-3. Rebuild the blog with `raco frog -b`
-4. Run `cd ..; raco frog -p` to start a web server and view your changes at [http://localhost:3000/](http://localhost:3000/)
-5. Remove the `DRAFT` tag
-6. Commit & push your blog post
+3. Add `Authors: [your name]` to the metadata
+4. Rebuild the blog with `raco frog -b`
+5. Run `cd ..; raco frog -p` to start a web server and view your changes at [http://localhost:3000/](http://localhost:3000/)
+6. Remove the `DRAFT` tag
+7. Commit & push your blog post

--- a/blog/_src/index-template.html
+++ b/blog/_src/index-template.html
@@ -2,6 +2,7 @@
   <header>
     <h2><a href='@|uri-path|'>@|title|</a></h2>
     <p class='date-and-tags'>@|date| :: @|tags|</p>
+    <p class='authors'>By: @|authors|</p>
   </header>
   @|content-only|
   @(when more?

--- a/blog/_src/post-template.html
+++ b/blog/_src/post-template.html
@@ -2,6 +2,7 @@
   <header>
     <h1>@|title|</h1>
     <p class='date-and-tags'>@|date| :: @|tags|</p>
+    <p class='authors'>By: @|authors|</p>
   </header>
   @|content|
   <br/><br/>

--- a/blog/_src/posts/2012-01-01-a-2012-blog-post.md
+++ b/blog/_src/posts/2012-01-01-a-2012-blog-post.md
@@ -1,6 +1,7 @@
     Title: A 2012 blog post
     Date: 2012-01-01T00:00:00
     Tags: foo, bar, tag with spaces, baz, DRAFT
+    Authors: PRL
 
 <!-- bg: This is a historic blog post by Greg Hendershott -->
 <!-- http://www.greghendershott.com/ -->

--- a/blog/_src/posts/2016-04-29-welcome-to-the-prl-blog.md
+++ b/blog/_src/posts/2016-04-29-welcome-to-the-prl-blog.md
@@ -1,6 +1,7 @@
     Title: Welcome to the PRL blog
     Date: 2016-04-29T14:50:29
-    Tags: about, 1st blog post, by Ben Greenman
+    Tags: about, 1st blog post
+    Authors: Ben Greenman
 
 Greetings, ground rules, hopes, dreams, and notes for contributors.
 Welcome aboard.

--- a/blog/_src/posts/2016-05-03-nepls-on-may-31st-at-umass-amherst.md
+++ b/blog/_src/posts/2016-05-03-nepls-on-may-31st-at-umass-amherst.md
@@ -1,6 +1,7 @@
     Title: NEPLS on May 31st at UMass, Amherst
     Date: 2016-05-03T08:21:07
-    Tags: NEPLS, conference, by Gabriel Scherer
+    Tags: NEPLS, conference
+    Authors: Gabriel Scherer
 
 It is my pleasure to relay the following announcement for the next
 edition of the New England Programming Language Seminer (NEPLS), to be

--- a/blog/_src/posts/2016-05-18-gradual-typing-across-the-spectrum.md
+++ b/blog/_src/posts/2016-05-18-gradual-typing-across-the-spectrum.md
@@ -1,6 +1,7 @@
     Title: Gradual Typing Across the Spectrum
     Date: 2016-05-18T07:58:56
-    Tags: gradual typing, PI meeting, by Asumu Takikawa
+    Tags: gradual typing, PI meeting
+    Authors: Asumu Takikawa
 
 > Instead of being Pythonistas, Rubyists, or Racketeers we have to
 > be scientists. -- Matthias Felleisen

--- a/blog/_src/posts/2016-05-24-measuring-gc-latencies-in-haskell-ocaml-racket.md
+++ b/blog/_src/posts/2016-05-24-measuring-gc-latencies-in-haskell-ocaml-racket.md
@@ -1,6 +1,7 @@
     Title: Measuring GC latencies in Haskell, OCaml, Racket
     Date: 2016-05-24T10:51:34
-    Tags: garbage collection,latency,instrumentation,haskell,ghc,ocaml,racket,by Gabriel Scherer
+    Tags: garbage collection,latency,instrumentation,haskell,ghc,ocaml,racket
+    Authors: Gabriel Scherer
 
 James Fisher has a blog post on a case where GHC's runtime system
 imposed unpleasant latencies on their Haskell program:

--- a/blog/_src/posts/2016-06-07-icfp-2016-looking-for-student-volunteers.md
+++ b/blog/_src/posts/2016-06-07-icfp-2016-looking-for-student-volunteers.md
@@ -1,6 +1,7 @@
     Title: ICFP 2016: looking for student volunteers
     Date: 2016-06-07T11:53:47
-    Tags: ICFP, by Gabriel Scherer
+    Tags: ICFP
+    Authors: Gabriel Scherer
 
 If you are a student, you should consider
 [applying](http://goo.gl/forms/fKg3vpjNryBlGWB32) to become an ICFP

--- a/blog/_src/posts/2016-06-13-does-anyone-still-care-about-printed-proceedings-grab-some-at-neu-this-week.md
+++ b/blog/_src/posts/2016-06-13-does-anyone-still-care-about-printed-proceedings-grab-some-at-neu-this-week.md
@@ -1,6 +1,7 @@
     Title: Does anyone still care about printed proceedings? (Grab some at NEU this week!)
     Date: 2016-06-13T10:50:14
-    Tags: proceedings,dawn of the digital era, by Gabriel Scherer
+    Tags: proceedings,dawn of the digital era
+    Authors: Gabriel Scherer
 
 Are you interested in printed conference Proceedings? We have a good
 stack of them left away at Northeastern University (Boston, MA) and it

--- a/blog/_src/posts/2016-06-27-tutorial-using-racket-s-ffi.scrbl
+++ b/blog/_src/posts/2016-06-27-tutorial-using-racket-s-ffi.scrbl
@@ -2,7 +2,8 @@
 
 Title: Tutorial: Using Racket's FFI
 Date: 2016-06-27T16:22:11
-Tags: Racket, FFI, tutorial, by Asumu Takikawa
+Tags: Racket, FFI, tutorial
+Authors: Asumu Takikawa
 
 @(require scribble/example
           scribble/racket

--- a/blog/_src/posts/2016-06-29-tutorial-racket-ffi-part-2.scrbl
+++ b/blog/_src/posts/2016-06-29-tutorial-racket-ffi-part-2.scrbl
@@ -2,7 +2,8 @@
 
 Title: Tutorial: Racket FFI, Part 2
 Date: 2016-06-29T18:48:17
-Tags: Racket, FFI, tutorial, by Asumu Takikawa
+Tags: Racket, FFI, tutorial
+Authors: Asumu Takikawa
 
 @(require scribble/example
           scribble/racket

--- a/blog/_src/posts/2016-07-11-tutorial-racket-ffi-part-3.scrbl
+++ b/blog/_src/posts/2016-07-11-tutorial-racket-ffi-part-3.scrbl
@@ -2,7 +2,8 @@
 
 Title: Tutorial: Racket FFI, part 3
 Date: 2016-07-11T17:33:40
-Tags: Racket, FFI, tutorial, by Asumu Takikawa
+Tags: Racket, FFI, tutorial
+Authors: Asumu Takikawa
 
 @(require scribble/example
           scribble/racket

--- a/blog/_src/posts/2016-07-25-tutorial-zero-to-sixty-in-racket.scrbl
+++ b/blog/_src/posts/2016-07-25-tutorial-zero-to-sixty-in-racket.scrbl
@@ -5,7 +5,8 @@
 
 Title: Tutorial: Zero to Sixty in Racket
 Date: 2016-08-02T01:29:11
-Tags: Racket, tutorial, by Ben Greenman
+Tags: Racket, tutorial
+Authors: Ben Greenman
 
 @(require scribble/example
           scribble/racket

--- a/blog/_src/posts/2016-08-03-a-few-cores-too-many.md
+++ b/blog/_src/posts/2016-08-03-a-few-cores-too-many.md
@@ -1,6 +1,7 @@
     Title: A few cores too many
     Date: 2016-08-03T14:09:02
-    Tags: performance, benchmarking, lost time, by Ben Greenman
+    Tags: performance, benchmarking, lost time
+    Authors: Ben Greenman
 
 Performance matters for software systems, but performance is not always easy
  to measure.

--- a/blog/_src/posts/2016-09-15-nepls-on-october-7th-at-northeastern.md
+++ b/blog/_src/posts/2016-09-15-nepls-on-october-7th-at-northeastern.md
@@ -1,6 +1,7 @@
     Title: NEPLS on October 7th at Northeastern University
     Date: 2016-09-15T21:18:45
-    Tags: NEPLS, conference, by Ben Greenman
+    Tags: NEPLS, conference
+    Authors: Ben Greenman
 
 The next edition of the New England Programming Language Seminar (NEPLS) will
 be held on Friday, October 7th at Northeastern University.

--- a/blog/_src/posts/2016-10-11-compcert-overview.md
+++ b/blog/_src/posts/2016-10-11-compcert-overview.md
@@ -1,6 +1,7 @@
     Title: CompCert Overview
     Date: 2016-10-11T17:41:16
-    Tags: tutorial, coq, compiler correctness, by Ben Greenman
+    Tags: tutorial, coq, compiler correctness
+    Authors: Ben Greenman
 
 If you are interested in learning about the _internals_ of the CompCert C
 compiler but would rather not read its source code, this post is for you.

--- a/blog/_src/posts/2016-10-17-emacs-daemon-for-fast-editor-startup.md
+++ b/blog/_src/posts/2016-10-17-emacs-daemon-for-fast-editor-startup.md
@@ -1,6 +1,7 @@
     Title: Emacs daemon for fast editor startup
     Date: 2016-10-17T21:48:25
-    Tags: System Administration, Emacs, by Gabriel Scherer
+    Tags: System Administration, Emacs
+    Authors: Gabriel Scherer
 
 In the early days of the famous Emacs/Vim debates, Emacs was often
 ridiculed for its bulkiness (Eight Megabytes-of-RAM And Constantly

--- a/blog/_src/posts/2016-10-19-history-of-actors.md
+++ b/blog/_src/posts/2016-10-19-history-of-actors.md
@@ -1,6 +1,7 @@
     Title: History of Actors
     Date: 2016-10-19T17:26:16
-    Tags: history, by Tony Garnock-Jones
+    Tags: history
+    Authors: Tony Garnock-Jones
 
 Christos Dimoulas is currently teaching a
 ["History of Programming Languages" class at Harvard](http://www.seas.harvard.edu/courses/cs252/2016fa/).

--- a/blog/_src/posts/2016-10-31-meaningful-distinctions.md
+++ b/blog/_src/posts/2016-10-31-meaningful-distinctions.md
@@ -1,6 +1,7 @@
     Title: Meaningful Distinctions
     Date: 2016-10-31T17:20:33
-    Tags: history, constructions, by Ben Greenman
+    Tags: history, constructions
+    Authors: Ben Greenman
 
 > "Meaningful distinctions deserve to be maintained." -- Errett A. Bishop
 

--- a/blog/_src/posts/2016-11-02-beta-reduction-part-1.md
+++ b/blog/_src/posts/2016-11-02-beta-reduction-part-1.md
@@ -1,6 +1,7 @@
     Title: Beta Reduction (Part 1)
     Date: 2016-11-02T21:10:18
-    Tags: lambda,calculus,beta,reduction,semantics,by Milo Davis
+    Tags: lambda,calculus,beta,reduction,semantics
+    Authors: Milo Davis
 
 The λ-calculus is often introduced by showing how to build a real programming language from it's simple syntactic forms.  In this series of post, I attempt to introduce it as a tool for modeling semantics.  So if you're opening [Barendregt](https://www.amazon.com/Calculus-Semantics-Studies-Foundations-Mathematics/dp/0444875085) for the first time, trying to understand a lecture from a programming languages or functional programming class, or just starting to become involved in PL research, I hope this post will help you understand evaluation by substitution (β-reduction).
 

--- a/blog/_src/posts/2016-11-16-constructive-galois-connections.md
+++ b/blog/_src/posts/2016-11-16-constructive-galois-connections.md
@@ -1,6 +1,7 @@
     Title: Understanding Constructive Galois Connections
     Date: 2016-11-16T00:00:00
-    Tags: icfp, galois connection, adjunction, category theory, math, by Max New
+    Tags: icfp, galois connection, adjunction, category theory, math
+    Authors: Max New
 
 One of my favorite papers at ICFP 2016 (in lovely
 [Nara, Japan](http://conf.researchr.org/home/icfp-2016)) was

--- a/blog/_src/posts/2016-11-17-src-submissions.md
+++ b/blog/_src/posts/2016-11-17-src-submissions.md
@@ -1,6 +1,7 @@
     Title: SRC-submissions
     Date: 2016-11-17T13:52:52
-    Tags: by Gabriel Scherer
+    Tags:
+    Authors: Gabriel Scherer
 
 Max New, Daniel Patterson and Ben Greenman recently wrote three
 two-page abstracts on what they are working on right now. Come have

--- a/blog/_src/posts/2016-11-30-getting-started-in-programming-languages-cross-post.md
+++ b/blog/_src/posts/2016-11-30-getting-started-in-programming-languages-cross-post.md
@@ -1,3 +1,4 @@
     Title: [Getting Started in Programming Languages (Cross-Post)](http://jschuster.org/blog/2016/11/29/getting-started-in-programming-languages/)
     Date: 2016-11-30T15:24:45
-    Tags: by Jonathan Schuster, tutorial, semantics, books
+    Tags: tutorial, semantics, books
+    Authors: Jonathan Schuster

--- a/blog/_src/posts/2016-12-17-measuring-the-submission-review-balance.md
+++ b/blog/_src/posts/2016-12-17-measuring-the-submission-review-balance.md
@@ -1,6 +1,7 @@
     Title: Measuring the submission/review balance
     Date: 2016-12-17T16:33:10
-    Tags: by Gabriel Scherer
+    Tags:
+    Authors: Gabriel Scherer
 
 How do researchers know whether they are doing "enough" or "too many"
 reviews? A measurable goal is to be review-neutral: to have demanded,

--- a/blog/_src/posts/2017-01-02-fall-2016-pl-junior-retrospective.md
+++ b/blog/_src/posts/2017-01-02-fall-2016-pl-junior-retrospective.md
@@ -1,6 +1,7 @@
     Title: Fall 2016 PL Junior Retrospective
     Date: 2017-01-02T16:39:37
-    Tags: PL Junior, by Ben Chung, by Milo Davis, by Ming-Ho Yee, by Sam Caldwell
+    Tags: PL Junior
+    Authors: Ben Chung, Milo Davis, Ming-Ho Yee, Sam Caldwell
 
 The [Programming Language Seminar, Junior] [10] (or “PL Junior”), is a
 seminar for junior students to learn and discuss topics at a pace more

--- a/blog/_src/posts/2017-01-03-toward-type-preserving-compilation-of-coq-at-popl17-src.md
+++ b/blog/_src/posts/2017-01-03-toward-type-preserving-compilation-of-coq-at-popl17-src.md
@@ -1,3 +1,4 @@
     Title: [Toward Type-Preserving Compilation of Coq, at POPL17 SRC (cross-post)](https://williamjbowman.com/blog/2017/01/03/toward-type-preserving-compilation-of-coq-at-popl17-src/)
     Date: 2017-01-03T15:15:57
-    Tags: by William J. Bowman
+    Tags:
+    Authors: William J. Bowman

--- a/blog/_src/posts/2017-02-15-hopl2017-conversational-context.md
+++ b/blog/_src/posts/2017-02-15-hopl2017-conversational-context.md
@@ -1,6 +1,7 @@
     Title: Conversational Context and Concurrency
     Date: 2017-02-15T01:21:55
-    Tags: HOPL, by Tony Garnock-Jones
+    Tags: HOPL
+    Authors: Tony Garnock-Jones
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-02-16-hopl2017-intro.md
+++ b/blog/_src/posts/2017-02-16-hopl2017-intro.md
@@ -1,6 +1,7 @@
     Title: Introducing HOPL 2017
     Date: 2017-02-15T01:21:37
-    Tags: HOPL, by Ben Greenman
+    Tags: HOPL
+    Authors: Ben Greenman
 
 This semester at Northeastern, Matthias Felleisen is organizing the
 [History of Programming Languages](http://www.ccs.neu.edu/home/matthias/7480-s17/index.html)

--- a/blog/_src/posts/2017-02-21-bullets-are-good-for-your-coq-proofs.md
+++ b/blog/_src/posts/2017-02-21-bullets-are-good-for-your-coq-proofs.md
@@ -1,6 +1,7 @@
     Title: Bullets are good for your Coq proofs
     Date: 2017-02-21T19:04:28
-    Tags: coq, by Gabriel Scherer
+    Tags: coq
+    Authors: Gabriel Scherer
 
 I believe that bullets are one of the most impactful features of
 recent versions of Coq, among those that non-super-expert users can

--- a/blog/_src/posts/2017-02-21-datalog-for-static-analysis.md
+++ b/blog/_src/posts/2017-02-21-datalog-for-static-analysis.md
@@ -1,6 +1,7 @@
     Title: Datalog for Static Analysis
     Date: 2017-02-21T12:58:27
-    Tags: HOPL, by Ben Greenman
+    Tags: HOPL
+    Authors: Ben Greenman
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-02-28-hopl2017-linear-types.md
+++ b/blog/_src/posts/2017-02-28-hopl2017-linear-types.md
@@ -1,6 +1,7 @@
     Title: Linear Types for Low-level Languages
     Date: 2017-02-28T09:51:55
-    Tags: HOPL, by Daniel Patterson
+    Tags: HOPL
+    Authors: Daniel Patterson
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-02-28-pliss-oregon-without-the-greek.md
+++ b/blog/_src/posts/2017-02-28-pliss-oregon-without-the-greek.md
@@ -1,6 +1,7 @@
     Title: PLISS: Oregon without the greek
     Date: 2017-02-28T23:01:00
-    Tags: event, lectures, language implementation, by Jan Vitek
+    Tags: event, lectures, language implementation
+    Authors: Jan Vitek
 
 What does every student interested in programming languages need to
 learn about the practical side of the field? That is the question that

--- a/blog/_src/posts/2017-03-03-metafunction-apply.md
+++ b/blog/_src/posts/2017-03-03-metafunction-apply.md
@@ -1,6 +1,7 @@
     Title: PLT Redex: mf-apply
     Date: 2017-03-03T08:54:20
-    Tags: PLT Redex, package, lang-extension, by Ben Greenman
+    Tags: PLT Redex, package, lang-extension
+    Authors: Ben Greenman
 
 The `mf-apply` keyword is for checked metafunction application in PLT Redex.
 In other words, `(mf-apply f x)` is just like `(f x)`, but errors if `f` is

--- a/blog/_src/posts/2017-03-10-hopl-stack.md
+++ b/blog/_src/posts/2017-03-10-hopl-stack.md
@@ -1,6 +1,7 @@
     Title: Type Inference in Stack-Based Programming Languages
     Date: 2017-03-10T16:23:30
-    Tags: HOPL, by Rob Kleffner
+    Tags: HOPL
+    Authors: Rob Kleffner
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-03-15-tracing-jits-for-dynamic-languages.md
+++ b/blog/_src/posts/2017-03-15-tracing-jits-for-dynamic-languages.md
@@ -1,6 +1,7 @@
     Title: Tracing JITs for Dynamic Languages
     Date: 2017-03-15T10:54:39
-    Tags: HOPL, by Ming-Ho Yee
+    Tags: HOPL
+    Authors: Ming-Ho Yee
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-03-24-what-even-is-compiler-correctness.md
+++ b/blog/_src/posts/2017-03-24-what-even-is-compiler-correctness.md
@@ -1,3 +1,4 @@
     Title: [What even is compiler correctness? (cross-post)](https://williamjbowman.com/blog/2017/03/24/what-even-is-compiler-correctness/)
     Date: 2017-03-24T23:11:17
-    Tags: by William J. Bowman
+    Tags:
+    Authors: William J. Bowman

--- a/blog/_src/posts/2017-04-04-top-5-in-last-50.md
+++ b/blog/_src/posts/2017-04-04-top-5-in-last-50.md
@@ -1,6 +1,7 @@
     Title: Top Five Results of the Past 50 Years of Programming Languages Research
     Date: 2017-04-04T10:21:36
-    Tags: HOPL, by Ben Greenman
+    Tags: HOPL
+    Authors: Ben Greenman
 
 Over the past 50 years, which result from programming languages research
 has had the greatest impact on working programmers?

--- a/blog/_src/posts/2017-04-17-hopl-types-in-compilation.md
+++ b/blog/_src/posts/2017-04-17-hopl-types-in-compilation.md
@@ -1,6 +1,7 @@
     Title: Type-Directed Compilation, Parts I and II
     Date: 2017-04-17T12:00:17
-    Tags: HOPL, by Leif Andersen, by William J. Bowman
+    Tags: HOPL
+    Authors: Leif Andersen, William J. Bowman
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-04-20-hopl-refinement-types.md
+++ b/blog/_src/posts/2017-04-20-hopl-refinement-types.md
@@ -1,6 +1,7 @@
     Title: Refinement Types
     Date: 2017-04-20T23:38:23
-    Tags: HOPL, by Kevin Clancy
+    Tags: HOPL
+    Authors: Kevin Clancy
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-04-25-prl-at-snapl-17.md
+++ b/blog/_src/posts/2017-04-25-prl-at-snapl-17.md
@@ -1,6 +1,7 @@
     Title: PRL at SNAPL'17
     Date: 2017-04-25T16:46:54
-    Tags: by Gabriel Scherer
+    Tags:
+    Authors: Gabriel Scherer
 
 PRL recently produced three papers for the
 [SNAPL](http://snapl.org/2017/index.html) conference.

--- a/blog/_src/posts/2017-04-28-hopl-soft-typing.md
+++ b/blog/_src/posts/2017-04-28-hopl-soft-typing.md
@@ -1,6 +1,7 @@
     Title: What is Soft Typing?
     Date: 2017-04-28T12:25:17
-    Tags: HOPL, by Ben Greenman
+    Tags: HOPL
+    Authors: Ben Greenman
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-05-01-hopl-dyn-cats.md
+++ b/blog/_src/posts/2017-05-01-hopl-dyn-cats.md
@@ -1,6 +1,7 @@
     Title: Categorical Semantics for Dynamically Typed Programming Languages
     Date: 2017-05-01T12:25:17
-    Tags: HOPL, category theory, dynamic typing, gradual typing, by Max New
+    Tags: HOPL, category theory, dynamic typing, gradual typing
+    Authors: Max New
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-05-04-rank-polymorphism.md
+++ b/blog/_src/posts/2017-05-04-rank-polymorphism.md
@@ -1,6 +1,7 @@
     Title: Rank Polymorphism
     Date: 2017-05-04T18:26:48
-    Tags: by Justin Slepak, array language, 
+    Tags: array language
+    Authors: Justin Slepak
 
 
 Rank polymorphism gives you code reuse on arguments of different dimensions.

--- a/blog/_src/posts/2017-05-09-hopl-no-good-answers.md
+++ b/blog/_src/posts/2017-05-09-hopl-no-good-answers.md
@@ -1,6 +1,7 @@
     Title: No Good Answers, Gradually Typed Object-Oriented Languages
     Date: 2017-05-09T14:04:31
-    Tags: HOPL, Gradual Typing, by Ben Chung
+    Tags: HOPL, Gradual Typing
+    Authors: Ben Chung
 
 <!-- more -->
 

--- a/blog/_src/posts/2017-05-15-artifacts-for-semantics.md
+++ b/blog/_src/posts/2017-05-15-artifacts-for-semantics.md
@@ -1,6 +1,7 @@
     Title: Artifacts for Semantics
     Date: 2017-05-15T10:08:31
-    Tags: by Daniel Patterson
+    Tags:
+    Authors: Daniel Patterson
 
 [Gabriel Scherer](http://gallium.inria.fr/~scherer/) and I recently wrote
 an [artifact](https://dbp.io/artifacts/funtal) for a

--- a/blog/_src/posts/2017-05-23-scribble-html.md
+++ b/blog/_src/posts/2017-05-23-scribble-html.md
@@ -1,6 +1,7 @@
     Title: Building a Website with Scribble
     Date: 2017-05-23T01:53:13
-    Tags: Scribble, tutorial, by Ben Greenman
+    Tags: Scribble, tutorial
+    Authors: Ben Greenman
 
 The source code for the PRL website is written using Scribble, the Racket
  documentation tool.

--- a/blog/_src/posts/2017-05-24-plc-russia.md
+++ b/blog/_src/posts/2017-05-24-plc-russia.md
@@ -1,6 +1,7 @@
     Title: Programming Language Conference in Russia
     Date: 2017-05-24T12:25:17
-    Tags: by Artem Pelenitsyn
+    Tags:
+    Authors: Artem Pelenitsyn
 
 In April 3--5 I took part into a Russian conference exclusively devoted to programming languages: [Programming Languages and Compilers][PLC] ([Google.Translated version of the site][PLCGT]). I was a member of organizing committee and had a paper there. 
 

--- a/blog/_src/posts/2017-05-26-racket-6-9-and-windows-10-creators-update.md
+++ b/blog/_src/posts/2017-05-26-racket-6-9-and-windows-10-creators-update.md
@@ -1,6 +1,7 @@
     Title: Racket 6.9 and Windows 10 Creators Update
     Date: 2017-05-26T17:00:28
-    Tags: racket, windows, bugs, by Leif Andersen
+    Tags: racket, windows, bugs
+    Authors: Leif Andersen
 
 [Racket][racket] 6.9 was released in April and it has been smooth sailing for
 many people. However, some people using the [Windows 10 Creators Update][WCU] have

--- a/blog/_src/posts/2017-06-05-syntactic-parametricity-strikes-again.md
+++ b/blog/_src/posts/2017-06-05-syntactic-parametricity-strikes-again.md
@@ -1,6 +1,7 @@
     Title: Syntactic parametricity strikes again
     Date: 2017-06-05T14:27:44
-    Tags: by Gabriel Scherer, by Li-Yao Xia
+    Tags:
+    Authors: Gabriel Scherer, Li-Yao Xia
 
 In this blog post, reporting on a collaboration with [Li-Yao
 Xia](https://poisson.chat/), I will show an example of

--- a/blog/_src/posts/2017-06-05-trip-report-pliss-2017.md
+++ b/blog/_src/posts/2017-06-05-trip-report-pliss-2017.md
@@ -1,6 +1,7 @@
     Title: Report: PLISS 2017
     Date: 2017-06-05T15:47:59
-    Tags: pliss, event, by Ming-Ho Yee
+    Tags: pliss, event
+    Authors: Ming-Ho Yee
 
 Two weeks ago, I attended the first [Programming Language Implementation Summer
 School][PLISS], held in beautiful Bertinoro, Italy.

--- a/blog/_src/posts/2017-06-09-bridging-the-system-configuration-gap.md
+++ b/blog/_src/posts/2017-06-09-bridging-the-system-configuration-gap.md
@@ -1,3 +1,4 @@
     Title: [Bridging the System Configuration Gap (Cross-Post)](https://aaronweiss.us/posts/2017-06-05-bridging-the-system-configuration-gap.html)
     Date: 2017-06-09T13:36:56
-    Tags: by Aaron Weiss
+    Tags:
+    Authors: Aaron Weiss

--- a/blog/_src/posts/2017-06-16-spring-2017-pl-junior-retrospective.md
+++ b/blog/_src/posts/2017-06-16-spring-2017-pl-junior-retrospective.md
@@ -1,6 +1,7 @@
     Title: Spring 2017 PL Junior Retrospective
     Date: 2017-06-16T11:38:25
-    Tags: PL Junior, by Ben Chung, by Milo Davis, by Ming-Ho Yee, by Matt Kolosick, by Dustin Jamner, by Artem Pelenitsyn, by Julia Belyakova, by Sam Caldwell
+    Tags: PL Junior
+    Authors: Ben Chung, Milo Davis, Ming-Ho Yee, Matt Kolosick, Dustin Jamner, Artem Pelenitsyn, Julia Belyakova, Sam Caldwell
 
 The [PL Junior Seminar][pljunior] is for beginning PhD and interested
 undergrad and masters students to understand the foundations of

--- a/blog/_src/posts/2017-06-24-turing-award-50.md
+++ b/blog/_src/posts/2017-06-24-turing-award-50.md
@@ -1,6 +1,7 @@
     Title: Quotes and Stories from "Turing 50"
     Date: 2017-06-24T20:00:52
-    Tags: dear diary, by Ben Greenman
+    Tags: dear diary
+    Authors: Ben Greenman
 
 The ACM recently hosted [a celebration of 50 years of the A.M. Turing award](https://www.acm.org/turing-award-50).
 These are some notes and thoughts from the event,

--- a/blog/_src/posts/2017-07-17-continuations-1983.md
+++ b/blog/_src/posts/2017-07-17-continuations-1983.md
@@ -1,6 +1,7 @@
     Title: Continuations
     Date: 2017-07-17T12:52:07
-    Tags: history, by Ben Greenman
+    Tags: history
+    Authors: Ben Greenman
 
 From the PRL archives:
 

--- a/blog/_src/posts/2017-07-19-trees-1973.md
+++ b/blog/_src/posts/2017-07-19-trees-1973.md
@@ -1,6 +1,7 @@
     Title: Trees, 1973
     Date: 2017-07-19T21:48:56
-    Tags: history, by Ben Greenman
+    Tags: history
+    Authors: Ben Greenman
 
 From the PRL archives:
 

--- a/blog/_src/posts/2017-08-13-reviews-and-author-responses.md
+++ b/blog/_src/posts/2017-08-13-reviews-and-author-responses.md
@@ -1,6 +1,7 @@
     Title: Reviews and author responses: we should stop asking for 500-word responses
     Date: 2017-08-13T14:29:41
-    Tags: by Gabriel Scherer
+    Tags:
+    Authors: Gabriel Scherer
 
 This year I reviewed many ICFP submissions, and got to be on the
 receiving end of equally many author responses (also sometimes called,

--- a/blog/_src/posts/2017-08-22-gradual-typing-across-the-spectrum.md
+++ b/blog/_src/posts/2017-08-22-gradual-typing-across-the-spectrum.md
@@ -1,6 +1,7 @@
     Title: Gradual Typing Across the Spectrum, part II
     Date: 2017-08-22T15:54:06
-    Tags: gradual typing, PI meeting, by Ben Greenman
+    Tags: gradual typing, PI meeting
+    Authors: Ben Greenman
 
 Last week, Northeastern hosted a PI meeting for the [Gradual Typing Across the
  Spectrum](http://prl.ccs.neu.edu/gtp/) NSF grant.

--- a/blog/_src/posts/2017-08-28-closure-conversion-coyoneda.md
+++ b/blog/_src/posts/2017-08-28-closure-conversion-coyoneda.md
@@ -1,6 +1,7 @@
     Title: Closure Conversion as CoYoneda
     Date: 2017-08-28T10:30:00
-    Tags: Yoneda, coYoneda, category theory, compilers, closure conversion, math, by Max New
+    Tags: Yoneda, coYoneda, category theory, compilers, closure conversion, math
+    Authors: Max New
 
 The continuation-passing style transform (cps) and closure conversion
 (cc) are two techniques widely employed by compilers for functional

--- a/blog/_src/posts/2017-08-29-why-am-i-going-to-icfp-2017.md
+++ b/blog/_src/posts/2017-08-29-why-am-i-going-to-icfp-2017.md
@@ -1,3 +1,4 @@
     Title: [Why am I going to ICFP 2017? (cross-post)](https://williamjbowman.com/blog/2017/08/29/why-am-i-going-to-icfp-2017/)
     Date: 2017-08-29T13:33:21
-    Tags: by William J. Bowman
+    Tags:
+    Authors: William J. Bowman

--- a/blog/_src/posts/2017-09-25-redex-faq.md
+++ b/blog/_src/posts/2017-09-25-redex-faq.md
@@ -1,6 +1,7 @@
     Title: PLT Redex FAQ
     Date: 2017-09-25T23:39:16
-    Tags: tutorial, PLT Redex, by Ben Greenman, by Sam Caldwell
+    Tags: tutorial, PLT Redex
+    Authors: Ben Greenman, Sam Caldwell
 
 A short guide to Redex concepts, conventions, and common mistakes.
 

--- a/blog/_src/posts/2017-09-27-final-algebra-semantics-is-observational-equivalence.md
+++ b/blog/_src/posts/2017-09-27-final-algebra-semantics-is-observational-equivalence.md
@@ -1,6 +1,7 @@
     Title: Final Algebra Semantics is Observational Equivalence
     Date: 2017-09-27T15:44:57
-    Tags: category theory, math, final encoding, observational equivalence, by Max New
+    Tags: category theory, math, final encoding, observational equivalence
+    Authors: Max New
 
 Recently, "final encodings" and "finally tagless style" have become
 popular techniques for defining embedded languages in functional

--- a/blog/_src/posts/2017-11-16-monotonicity-types-towards-a-type-system-for-eventual-consistency.md
+++ b/blog/_src/posts/2017-11-16-monotonicity-types-towards-a-type-system-for-eventual-consistency.md
@@ -1,6 +1,7 @@
     Title: Monotonicity Types: Towards A Type System for Eventual Consistency
     Date: 2017-10-22T11:59:06
-    Tags: types, monotonicity, CRDTs, eventual consistency, by Kevin Clancy
+    Tags: types, monotonicity, CRDTs, eventual consistency
+    Authors: Kevin Clancy
 
 
 A few weeks back, we published a draft of an article entitled [_Monotonicity Types_](https://infoscience.epfl.ch/record/231867). In it, we describe a type system which we hope can aid the design of distributed systems by tracking monotonicity with types.

--- a/blog/_src/posts/2018-01-17-how-to-prove-a-compiler-correct.md
+++ b/blog/_src/posts/2018-01-17-how-to-prove-a-compiler-correct.md
@@ -1,4 +1,5 @@
     Title: [How to prove a compiler correct (cross-post)](https://dbp.io/essays/2018-01-16-how-to-prove-a-compiler-correct.html)
     Date: 2018-01-17T20:58:48
-    Tags: by Daniel Patterson
+    Tags:
+    Authors: Daniel Patterson
 

--- a/blog/_src/posts/2018-01-19-untyped-programs-don-t-exist.md
+++ b/blog/_src/posts/2018-01-19-untyped-programs-don-t-exist.md
@@ -1,3 +1,4 @@
     Title: [Untyped Programs Don't Exist (cross-post)](https://williamjbowman.com/blog/2018/01/19/untyped-programs-don-t-exist/)
     Date: 2018-01-19T17:05:00
-    Tags: by William J. Bowman
+    Tags:
+    Authors: William J. Bowman

--- a/blog/_src/posts/2018-04-12-making-an-ide-plugin-for-drracket.md
+++ b/blog/_src/posts/2018-04-12-making-an-ide-plugin-for-drracket.md
@@ -1,4 +1,5 @@
     Title: [Making an IDE Plugin for DrRacket (cross-post)](https://lang.video/blog/2018/03/21/making-an-ide-plugin-for-drracket/)
     Date: 2018-04-12T12:12:53
-    Tags: tutorials, by Leif Andersen
+    Tags: tutorials
+    Authors: Leif Andersen
 

--- a/blog/_src/posts/2018-04-23-how-to-prove-a-compiler-fully-abstract.md
+++ b/blog/_src/posts/2018-04-23-how-to-prove-a-compiler-fully-abstract.md
@@ -1,3 +1,4 @@
     Title: [How to prove a compiler fully abstract (cross-post)](https://dbp.io/essays/2018-04-19-how-to-prove-a-compiler-fully-abstract.html)
     Date: 2018-04-23T10:07:48
-    Tags: by Daniel Patterson
+    Tags:
+    Authors: Daniel Patterson

--- a/blog/_src/posts/2018-04-27-racket-school-2018.md
+++ b/blog/_src/posts/2018-04-27-racket-school-2018.md
@@ -1,6 +1,7 @@
     Title: The Racket School 2018: Create your own language
     Date: 2018-04-27T21:35:22
-    Tags: event, Racket, by Ben Greenman
+    Tags: event, Racket
+    Authors: Ben Greenman
 
 The Racket School 2018: Create your own language • 9–13 July • Salt Lake City
 

--- a/blog/_src/posts/2018-05-08-sampling-gradual-typing-performance.md
+++ b/blog/_src/posts/2018-05-08-sampling-gradual-typing-performance.md
@@ -1,6 +1,7 @@
     Title: Sampling Gradual Typing Performance
     Date: 2018-05-08T15:37:37
-    Tags: gradual typing, migratory typing, performance, statistics, Takikawa constant, by Ben Greenman, by Zeina Migeed
+    Tags: gradual typing, migratory typing, performance, statistics, Takikawa constant
+    Authors: Ben Greenman, Zeina Migeed
 
 This post explains the sampling method introduced in the paper [_On the Cost of Type-Tag Soundness_](http://www.ccs.neu.edu/home/types/publications/publications.html#gm-pepm-2018)
 

--- a/blog/_src/posts/2018-10-06-a-spectrum-of-type-soundness-and-performance.md
+++ b/blog/_src/posts/2018-10-06-a-spectrum-of-type-soundness-and-performance.md
@@ -1,6 +1,7 @@
     Title: A Spectrum of Type Soundness and Performance
     Date: 2018-10-06T11:23:35
-    Tags: migratory typing, gradual typing, extended abstract, by Ben Greenman
+    Tags: migratory typing, gradual typing, extended abstract
+    Authors: Ben Greenman
 
 The literature on mixed-typed languages presents (at least) three fundamentally
 different ways of thinking about the integrity of programs that combine 

--- a/blog/_src/posts/2018-10-22-defining-local-bindings-in-turnstile-languages.md
+++ b/blog/_src/posts/2018-10-22-defining-local-bindings-in-turnstile-languages.md
@@ -1,6 +1,7 @@
     Title: Defining Local Bindings in Turnstile Languages
     Date: 2018-10-22T15:05:17
-    Tags: turnstile, tutorial, language, dsl, by Sam Caldwell
+    Tags: turnstile, tutorial, language, dsl
+    Authors: Sam Caldwell
 
 In [Racket][2], programmers can create powerful abstractions by bundling
 together a family of values, functions, and syntax extensions in the form of a

--- a/blog/_src/posts/2018-11-24-disappearing-code.md
+++ b/blog/_src/posts/2018-11-24-disappearing-code.md
@@ -1,6 +1,7 @@
     Title: Disappearing Code
     Date: 2018-11-24T09:52:58
-    Tags: dear diary, by Ben Greenman
+    Tags: dear diary
+    Authors: Ben Greenman
 
 Two experiences at [SPLASH 2018](https://2018.splashcon.org/home)
 reminded me that software gets thrown away and replaced.

--- a/blog/_src/posts/2018-11-30-turnstile-community.md
+++ b/blog/_src/posts/2018-11-30-turnstile-community.md
@@ -1,6 +1,7 @@
     Title: Turnstile Mailing List
     Date: 2018-11-30T14:55:30
-    Tags: announcement, turnstile, by Stephen Chang
+    Tags: announcement, turnstile
+    Authors: Stephen Chang
 
 [Turnstile](https://docs.racket-lang.org/turnstile/The_Turnstile_Guide.html)
 now has a mailing list: <https://groups.google.com/forum/#!forum/turnstile-users>

--- a/blog/_src/posts/2018-12-02-java-transient.md
+++ b/blog/_src/posts/2018-12-02-java-transient.md
@@ -1,6 +1,7 @@
     Title: Java and Migratory Typing
     Date: 2018-12-02T14:41:53
-    Tags: migratory typing, java, transient, by Ben Greenman
+    Tags: migratory typing, java, transient
+    Authors: Ben Greenman
 
 The _transient_ approach to migratory typing (circa [2014](http://homes.sice.indiana.edu/mvitouse/papers/dls14.pdf))
   is similar to type erasure in Java (circa [2004](https://docs.oracle.com/javase/1.5.0/docs/relnotes/features.html))

--- a/blog/_src/posts/2018-12-11-the-behavior-of-gradual-types.md
+++ b/blog/_src/posts/2018-12-11-the-behavior-of-gradual-types.md
@@ -1,6 +1,7 @@
     Title: The Behavior of Gradual Types: A User Study
     Date: 2018-12-11T19:50:33
-    Tags: migratory typing, gradual typing, extended abstract, by Ben Greenman
+    Tags: migratory typing, gradual typing, extended abstract
+    Authors: Ben Greenman
 
 <!-- more -->
 

--- a/blog/_src/posts/2019-01-28-on-stack-replacement.md
+++ b/blog/_src/posts/2019-01-28-on-stack-replacement.md
@@ -1,6 +1,7 @@
     Title: On-Stack Replacement
     Date: 2019-01-28T10:29:57
-    Tags: by Ming-Ho Yee
+    Tags:
+    Authors: Ming-Ho Yee
 
 Last semester, I took [a course][cs7600] where the final project was to write a
 survey paper on "a topic in the intersection between computer systems and your

--- a/blog/_src/posts/2019-02-17-scribble-acmart.md
+++ b/blog/_src/posts/2019-02-17-scribble-acmart.md
@@ -1,6 +1,7 @@
     Title: Writing a paper with Scribble
     Date: 2019-02-17T16:20:50
-    Tags: Scribble, tutorial, by Ben Greenman
+    Tags: Scribble, tutorial
+    Authors: Ben Greenman
 
 This post explains how to get started using Scribble to write a research paper.
 

--- a/blog/_src/posts/2019-03-09-pliss-learn-about-pl-implementation-in-a-castle.md
+++ b/blog/_src/posts/2019-03-09-pliss-learn-about-pl-implementation-in-a-castle.md
@@ -1,6 +1,7 @@
     Title: PLISS: Learn About PL Implementation in a Castle
     Date: 2019-03-09T14:40:16
-    Tags: event, lectures, castle, language implementation, by Alexi Turcotte
+    Tags: event, lectures, castle, language implementation
+    Authors: Alexi Turcotte
 
 We love programming languages (PLs), and we should all be in on the ins and outs of
 implementing them.

--- a/blog/_src/posts/2019-04-07-forgetful-and-heedful-contracts.md
+++ b/blog/_src/posts/2019-04-07-forgetful-and-heedful-contracts.md
@@ -1,6 +1,7 @@
     Title: Forgetful and Heedful contracts
     Date: 2019-04-07T23:15:11
-    Tags: migratory typing, higher-order contracts, by Ben Greenman
+    Tags: migratory typing, higher-order contracts
+    Authors: Ben Greenman
 
 _Forgetful_ and _heedful_ are two methods for space-efficient contracts
  developed by [Michael Greenberg](http://www.cs.pomona.edu/~michael/) in [2014][g].

--- a/blog/_src/posts/2019-05-11-conversational-concurrency.md
+++ b/blog/_src/posts/2019-05-11-conversational-concurrency.md
@@ -1,4 +1,5 @@
     Title: [Conversational Concurrency (cross-post)](https://eighty-twenty.org/2018/01/24/conversational-concurrency)
     Date: 2019-05-11T00:03:16
-    Tags: dissertation, by Tony Garnock-Jones
+    Tags: dissertation
+    Authors: Tony Garnock-Jones
 

--- a/blog/_src/posts/2019-09-05-lexical-and-dynamic-scope.md
+++ b/blog/_src/posts/2019-09-05-lexical-and-dynamic-scope.md
@@ -1,6 +1,7 @@
     Title: Lexical and Dynamic Scope
     Date: 2019-09-05T10:00:00
-    Tags: scope, definitions, history, by Ming-Ho Yee
+    Tags: scope, definitions, history
+    Authors: Ming-Ho Yee
 
 This all started with a simple question about the R programming language: _is R
 lexically or dynamically scoped?_

--- a/blog/_src/posts/2019-09-10-four-kinds-of-scoping-in-r.md
+++ b/blog/_src/posts/2019-09-10-four-kinds-of-scoping-in-r.md
@@ -1,6 +1,7 @@
     Title: Four Kinds of Scoping in R
     Date: 2019-09-10T11:00:00
-    Tags: scope, r, by Ming-Ho Yee
+    Tags: scope, r
+    Authors: Ming-Ho Yee
 
 In the [first](/blog/2019/09/05/lexical-and-dynamic-scope/) and
 [second](/blog/2019/09/10/scoping-in-r/) parts of this blog series, I defined

--- a/blog/_src/posts/2019-09-10-scoping-in-r.md
+++ b/blog/_src/posts/2019-09-10-scoping-in-r.md
@@ -1,6 +1,7 @@
     Title: Scoping in R
     Date: 2019-09-10T10:00:00
-    Tags: scope, r, by Ming-Ho Yee
+    Tags: scope, r
+    Authors: Ming-Ho Yee
 
 In the [previous post](/blog/2019/09/05/lexical-and-dynamic-scope/) of this
 three-part blog series, we discussed lexical and dynamic scope. Now, in this

--- a/blog/_src/posts/2019-10-31-complete-monitors-for-gradual-types.md
+++ b/blog/_src/posts/2019-10-31-complete-monitors-for-gradual-types.md
@@ -1,6 +1,7 @@
     Title: Complete Monitors for Gradual Types
     Date: 2019-10-31T21:58:26
-    Tags: migratory typing, gradual typing, complete monitoring, extended abstract, by Ben Greenman
+    Tags: migratory typing, gradual typing, complete monitoring, extended abstract
+    Authors: Ben Greenman
 
 Syntactic type soundness is too weak to tell apart different ways of running
  a program that mixes typed and untyped code.

--- a/blog/_src/posts/2019-12-12-prl-offsite-2019.md
+++ b/blog/_src/posts/2019-12-12-prl-offsite-2019.md
@@ -1,6 +1,7 @@
     Title: PRL Offsite 2019 Retrospective
     Date: 2019-12-12T12:51:53
-    Tags: offsite, by Ben Greenman, by Olek Gierczak
+    Tags: offsite
+    Authors: Ben Greenman, Olek Gierczak
 
 On November 11th 2019, the PRL had a private offsite meeting at the
  [More Than Words bookstore][mtw] in downtown Boston.

--- a/blog/_src/posts/2020-01-15-tr-optimizer-vs-transient.md
+++ b/blog/_src/posts/2020-01-15-tr-optimizer-vs-transient.md
@@ -1,6 +1,7 @@
     Title: The Typed Racket Optimizer vs. Transient
     Date: 2020-01-15T12:16:35
-    Tags: typed racket, transient, offsite, by Ben Greenman
+    Tags: typed racket, transient, offsite
+    Authors: Ben Greenman
 
 What type-directed optimizations does Typed Racket perform
  and do any require full types?

--- a/blog/_src/posts/2020-10-15-shallow-mailing-list.md
+++ b/blog/_src/posts/2020-10-15-shallow-mailing-list.md
@@ -1,6 +1,7 @@
     Title: Transient Answers Old Questions
     Date: 2020-10-15T13:32:12
-    Tags: typed racket, transient, by Ben Greenman
+    Tags: typed racket, transient
+    Authors: Ben Greenman
 
 Several old questions from the Typed Racket mailing list have new and simple
 answers under a "transient" Typed Racket.

--- a/blog/_src/posts/2020-11-12-transient-opt-kw-lambda.md
+++ b/blog/_src/posts/2020-11-12-transient-opt-kw-lambda.md
@@ -1,6 +1,7 @@
     Title: Transient for Optional and Keyword Functions
     Date: 2020-11-12T10:15:16
-    Tags: typed racket, transient, by Ben Greenman
+    Tags: typed racket, transient
+    Authors: Ben Greenman
 
 A short adventure into the depths of optional and/or keyword
  functions in Racket.

--- a/blog/_src/posts/2020-12-23-deep-and-shallow-types.md
+++ b/blog/_src/posts/2020-12-23-deep-and-shallow-types.md
@@ -1,6 +1,7 @@
     Title: Deep and Shallow Types
     Date: 2020-12-23T18:21:55
-    Tags: dissertation, migratory typing, by Ben Greenman
+    Tags: dissertation, migratory typing
+    Authors: Ben Greenman
 
 I successfully defended my Ph.D. dissertation.
 You can find the document, a talk recording, and much more here:


### PR DESCRIPTION
Templates are updated to show blog authors. Blog posts now need to specify author metadata, otherwise the author will show up as "PRL."

One inconvenience is that "new blog post" template does not contain the Authors field; [this is something that needs to be fixed in Frog](https://github.com/greghendershott/frog/blob/master/frog/private/new-post.rkt#L58L60). So we need to do it manually.

Screenshot of the blog index.
![image](https://user-images.githubusercontent.com/547059/131736421-a0852f9c-6e01-43d0-aeb4-8a19ebd7e5d6.png)

Screenshots of blog posts.
![image](https://user-images.githubusercontent.com/547059/131736448-e61e9a1e-fbee-49f0-a927-a2309969c5d8.png)

Closes #5 