### PR TITLE
comment out pending talk, update calendar link

### DIFF
--- a/seminars.rkt
+++ b/seminars.rkt
@@ -90,7 +90,7 @@
      "WVH 366 and Zoom"
      @list{@p{TBD}}
      @list{@p{"Nada Amin is an Assistant Professor of Computer Science at Harvard SEAS. Previously, she was a University Lecturer in Programming Languages at the University of Cambridge;  a member of the team behind the Scala programming language at the Ecole Polytechnique Federale de Lausanne (EPFL), where she pursued her PhD; and a software engineer at Google, on the compiler infrastructure supporting Gmail and other Google Apps. She holds bachelor of science and master of engineering degrees from the Massachusetts Institute of Technology (MIT)."}})
-    (seminar
+    #;(seminar
      "heineman-synthexp"
      "Synthesizing Solutions to the Expression Problem"
      "George T. Heineman"
@@ -1562,9 +1562,10 @@ a Dr. sc. ETH in 2012.
               and on @a[href: "https://northeastern.zoom.us/j/98598689387?pwd=Z0tyT2FFdFVsZGFKbDltMjRhS095Zz09"]{Zoom}
               on Fridays from 1:00-3:25pm (ET).
               The @a[href: "http://lists.ccs.neu.edu/pipermail/pl-seminar"]{mailing list} is public.
-              An @a[href: "https://outlook.office365.com/owa/calendar/a3c884a0aa1a44258f5f6ab04f328737@northeastern.edu/968391c9df94443a93cb6afecd2562c813340509926710825269/calendar.html"]{HTML calendar}
-              and an @a[href: "https://outlook.office365.com/owa/calendar/a3c884a0aa1a44258f5f6ab04f328737@northeastern.edu/968391c9df94443a93cb6afecd2562c813340509926710825269/calendar.ics"]{ICAL calendar}
-              are available for your convenience. (Note: These calendars were changed in Fall 2021, so returning attendees should resubscribe.)}}}
+              A calendar 
+	      (@a[href: "https://calendar.google.com/calendar/embed?src=k4cg1vgb3l2n8r2ph4t01dmtpc%40group.calendar.google.com&ctz=America%2FNew_York"]{HTML}
+		| @a[href: "https://calendar.google.com/calendar/ical/k4cg1vgb3l2n8r2ph4t01dmtpc%40group.calendar.google.com/public/basic.ics"]{iCal})
+              is available for your convenience. (Note: We temporarily switched to a new calendar at the start of Fall 2021, but we reverted that change. This link is current!)}}}
 
          @br{}
 


### PR DESCRIPTION
- George's talk is going to be rescheduled, so for now I've commented
  out the entry.
- We're reverting back to the old Google calendar, so I've switched the
  links. I also added a note about the potential confusion.