### PR TITLE
GHA: update setup-racket action, return caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-#      - name: Cache Racket dependencies
-#        uses: actions/cache@v2
-#        with:
-#          path: |
-#            ~/.cache/racket
-#            ~/.local/share/racket
-#          key: default
+      - name: Cache Racket dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/racket
+            ~/.local/share/racket
+          key: default
       - name: Install Racket
-        uses: Bogdanp/setup-racket@v0.8
+        uses: Bogdanp/setup-racket@v1.7
         with:
           architecture: 'x64'
           distribution: 'full'


### PR DESCRIPTION
After the [latest update][u] of the setup-racket action (v1.7), caching works correctly with packages, so updating the action and putting caching back.

[u]: https://github.com/Bogdanp/setup-racket/releases/tag/v1.7