### PR TITLE
Don't load IE resources on other browsers; update URIs

### DIFF
--- a/templates.rkt
+++ b/templates.rkt
@@ -54,17 +54,18 @@
            type: "text/css"]
 
      @<!--{For IE 9 and below. ICO should be 32x32 pixels in size}
-     @<!--{[if IE]><link rel="shortcut icon" href="img/favicon.ico"><![endif]}
+     @; <!--[if IE] doesn't support whitespace
+     @literal{<!--[if IE]><link rel="shortcut icon" href="img/favicon.ico"><![endif]-->}
 
      @<!--{Firefox, Chrome, Safari, IE 11+ and Opera. 196x196 pixels in size.}
      @link[rel: "icon" href: "img/favicon.png"]
 
      @<!--{HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries}
      @<!--{WARNING: Respond.js doesn't work if you view the page via file://}
-     @<!--{[if lt IE 9]}
-       @script[src: "https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"]
-       @script[src: "https://oss.maxcdn.com/respond/1.4.2/respond.min.js"]
-     @<!--{<![endif]} })
+     @literal[@list[ "<!--[if lt IE 9]"
+       @script[src: "https://cdn.jsdelivr.net/html5shiv/3.7.2/html5shiv.min.js"]
+       @script[src: "https://cdn.jsdelivr.net/respond/1.4.2/respond.min.js"]
+       "<![endif]-->" ]]})
 
 @(define (footer)
    @list{

--- a/templates.rkt
+++ b/templates.rkt
@@ -53,19 +53,8 @@
            rel: "stylesheet"
            type: "text/css"]
 
-     @<!--{For IE 9 and below. ICO should be 32x32 pixels in size}
-     @; <!--[if IE] doesn't support whitespace
-     @literal{<!--[if IE]><link rel="shortcut icon" href="img/favicon.ico"><![endif]-->}
-
-     @<!--{Firefox, Chrome, Safari, IE 11+ and Opera. 196x196 pixels in size.}
-     @link[rel: "icon" href: "img/favicon.png"]
-
-     @<!--{HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries}
-     @<!--{WARNING: Respond.js doesn't work if you view the page via file://}
-     @literal[@list[ "<!--[if lt IE 9]"
-       @script[src: "https://cdn.jsdelivr.net/html5shiv/3.7.2/html5shiv.min.js"]
-       @script[src: "https://cdn.jsdelivr.net/respond/1.4.2/respond.min.js"]
-       "<![endif]-->" ]]})
+     @<!--{196x196 pixels in size.}
+     @link[rel: "icon" href: "img/favicon.png"] })
 
 @(define (footer)
    @list{


### PR DESCRIPTION
The page requests two HTML5 polyfills.   These are supposed to be conditional on IE < 9, but a typo makes them unconditional.   This usually doesn't matter much, but the CDN we were referencing no longer serves them at that URI.   So this updates the URI and makes them conditional.   I checked that most pages render reasonably in current Firefox and current Chromium with this change, but **did not test in Internet Explorer**.    If someone wants to check it, be my guest, but i'm not worried about it if no one else is.