### PR TITLE
Wrap publications like other main content (Fixes #327)

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -422,6 +422,8 @@ ul
 .pn-pub-group
 {
     margin-bottom: 20px;
+    width: 80%;
+    margin: 0 auto;
 }
 
 .pn-pub-year

--- a/css/custom.css
+++ b/css/custom.css
@@ -421,7 +421,6 @@ ul
 
 .pn-pub-group
 {
-    margin-left: 30%;
     margin-bottom: 20px;
 }
 

--- a/publications.rkt
+++ b/publications.rkt
@@ -1519,7 +1519,7 @@
    (sort unsorted-groups > #:key publication-group-year))
 
 @(define (publication-group->html pub-group)
-   @div[class: "pn-pub-group col-md-12 compact"]{
+   @div[class: "pn-pub-group compact"]{
      @span[class: "pn-pub-year " (publication-group-year pub-group)]
      @br{}
      @(map publication->html (publication-group-publications pub-group))})

--- a/publications.rkt
+++ b/publications.rkt
@@ -1532,8 +1532,9 @@
    @subpage-title{Publications}
 
    @div[class: "pn-main-wrapper"]{
-     @div[class: "row"]{
-       @(map publication-group->html
-             (arrange-publications publications))}}
+     @div[class: "container"]{
+       @div[class: "row"]{
+         @(map publication-group->html
+               (arrange-publications publications))}}}
    @footer{}
 }}


### PR DESCRIPTION
It's still quite wide on wide screens, but this follows the convention seemingly followed by the rest of the site